### PR TITLE
[feat/#13] 이력서 업로드 API 구현

### DIFF
--- a/apps/settings.py
+++ b/apps/settings.py
@@ -143,3 +143,6 @@ STATIC_URL = 'static/'
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+MEDIA_ROOT = os.path.join(BASE_DIR, "user_resumes")
+MEDIA_URL = "/user_resumes/"

--- a/apps/urls.py
+++ b/apps/urls.py
@@ -30,7 +30,8 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path("admin/", admin.site.urls),
     path("users/", include("user.urls")),
-    path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path("resumes/", include("resume.urls")),
+    path("swagger/", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
 ]

--- a/resume/permission.py
+++ b/resume/permission.py
@@ -1,0 +1,8 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.exceptions import AuthenticationFailed
+
+class IsAuthenticatedCustom(IsAuthenticated):
+    def has_permission(self, request, view):
+        if not request.user or request.user.is_anonymous:
+            raise AuthenticationFailed("로그인이 필요합니다.")
+        return super().has_permission(request, view)

--- a/resume/serializers.py
+++ b/resume/serializers.py
@@ -1,0 +1,11 @@
+from rest_framework import serializers
+
+class ResumeUploadSerializer(serializers.Serializer):
+    file = serializers.FileField(
+        required=True,
+        allow_empty_file=False,
+        help_text="이력서 파일 (PDF)"
+    )
+
+
+

--- a/resume/urls.py
+++ b/resume/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from resume import views
+
+appname = "resume"
+
+urlpatterns = [path("upload", views.ResumeUploadView.as_view(), name="upload"),]
+
+path("upload", views.ResumeUploadView.as_view(), name="upload")

--- a/resume/views.py
+++ b/resume/views.py
@@ -1,3 +1,45 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework.parsers import MultiPartParser, FormParser
+from rest_framework import status
+from django.core.files.storage import default_storage
+from django.core.files.base import ContentFile
+from resume.models import Resume
+from resume.serializers import ResumeUploadSerializer
+from drf_yasg.utils import swagger_auto_schema
+from resume.permission import IsAuthenticatedCustom
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
 
-# Create your views here.
+@method_decorator(csrf_exempt, name="dispatch")
+class ResumeUploadView(APIView):
+    parser_classes = (MultiPartParser, FormParser)
+    permission_classes = [IsAuthenticatedCustom]
+
+    @swagger_auto_schema(
+        request_body=ResumeUploadSerializer,
+        operation_id="이력서 업로드 API",
+    )
+    def post(self, request):
+        user = request.user
+
+        file = request.FILES.get("file")
+
+        if not file:
+            return Response({"error": "파일을 업로드하세요."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not file.name.endswith('.pdf'):
+            return Response({"error": "PDF 파일만 업로드할 수 있습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        file_path = f"resume/{user.id}/{file.name}"
+        saved_path = default_storage.save(file_path, ContentFile(file.read()))
+        file_url = default_storage.url(saved_path)
+
+        resume = Resume.objects.create(user=user, filename=file.name, file_url=file_url)
+
+        return Response({
+            "message": "이력서 업로드 성공",
+            "resume_id": resume.id,
+            "filename": resume.filename,
+            "file_url": resume.file_url
+        }, status=status.HTTP_201_CREATED)

--- a/user/urls.py
+++ b/user/urls.py
@@ -5,4 +5,4 @@ appname = "user"
 
 urlpatterns = [path("register", views.UserRegistrationView.as_view(), name="sign-up"),]
 
-path('register', views.UserRegistrationView.as_view(), name='sign-up')
+path("register", views.UserRegistrationView.as_view(), name="sign-up")


### PR DESCRIPTION
# 설명
- 이력서(PDF) 업로드 기능추가
- 업로드된 pdf 파일은 사용자별 별도경로에 저장(현재는 로컬폴더)
- 업로드된 pdf 정보는 DB 테이블(resume_resume)에 저장

# 작업내용
- apps/settings.py (업로드된 pdf 저장경로 지정)
- apps/urls.py (작은따옴표 → 큰따옴표 수정 / resume앱 url 매핑 내용추가)
- resume/permisson.py (비로그인시 예외처리 기능 파일추가)
- resume/serializers.py (swagger 표시 파일추가)
- resume/urls.py (resume url 패턴정의 파일추가)
- resume/views.py (이력서 업로드 뷰 내용추가)
- user/urls.py (작은따옴표 → 큰따옴표 수정)

(이슈에 대한 작업완료시) close #이슈번호

* 모든 내용은 한글로 작성
