### PR TITLE
[fix/40]: 면접 영상 s3 저장 경로 수정

### DIFF
--- a/result/views.py
+++ b/result/views.py
@@ -14,7 +14,8 @@ class ResultVideoUploadView(APIView):
 
     @swagger_auto_schema(
         request_body=ResultVideoUploadSerializer,
-        operation_id="결과 업로드 API",
+        operation_id="면접 영상 업로드 API",
+        operation_description="면접 영상을 s3에 업로드 하는 API",
     )
     def post(self, request, interview_id):
         #user = request.user
@@ -29,7 +30,7 @@ class ResultVideoUploadView(APIView):
         interview = Interview.objects.get(id=interview_id)
         user_id = interview.user.id
 
-        video_path = f"video/{user_id}/{video.name}"
+        video_path = f"video/{user_id}/{interview_id}/{video.name}"
         saved_path = default_storage.save(video_path, ContentFile(video.read()))
         video_url = default_storage.url(saved_path)
 


### PR DESCRIPTION
# 설명
-  면접 영상 s3 저장 경로 수정

# 작업내용
- 기존의 s3 저장 경로가 user_id/vedio_name로 되어있어 면접 영상 이름이 동일하면 기존 면접 영상이 새로운 면접 영상으로 덮어씌워지는 문제가 발생
- 이를 해결하기 위해 user_id/interview_id/video_name으로 경로 수정
- 이제 사용자별, 면접별로 면접 영상 분류되어 저장됨


(이슈에 대한 작업완료시) close #40 

* 모든 내용은 한글로 작성
