### PR TITLE
[Feat/#51] 이력서 삭제 api 구현

### DIFF
--- a/resume/urls.py
+++ b/resume/urls.py
@@ -5,5 +5,6 @@ appname = "resume"
 
 urlpatterns = [
     path("upload/<user_id>", views.ResumeUploadView.as_view(), name="upload"),
+    path("list/<user_id>", views.ResumeListView.as_view(), name="resumes-list"),
     path("delete/<resume_id>", views.ResumeDeleteView.as_view(), name="delete"),
 ]

--- a/resume/urls.py
+++ b/resume/urls.py
@@ -3,4 +3,7 @@ from resume import views
 
 appname = "resume"
 
-urlpatterns = [path("upload/<user_id>", views.ResumeUploadView.as_view(), name="upload"),]
+urlpatterns = [
+    path("upload/<user_id>", views.ResumeUploadView.as_view(), name="upload"),
+    path("delete/<resume_id>", views.ResumeDeleteView.as_view(), name="delete"),
+]

--- a/resume/views.py
+++ b/resume/views.py
@@ -4,6 +4,7 @@ from rest_framework.parsers import MultiPartParser, FormParser
 from rest_framework import status
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
+from django.conf import settings
 from resume.models import Resume
 from resume.serializers import ResumeUploadSerializer
 from drf_yasg.utils import swagger_auto_schema
@@ -13,7 +14,7 @@ class ResumeUploadView(APIView):
 
     @swagger_auto_schema(
         request_body=ResumeUploadSerializer,
-        operation_id="이력서 업로드 API",
+        operation_id="이력서 업로드",
     )
     def post(self, request, user_id):
         #user = request.user
@@ -37,3 +38,14 @@ class ResumeUploadView(APIView):
             "filename": resume.filename,
             "file_url": resume.file_url
         }, status=status.HTTP_201_CREATED)
+
+class ResumeDeleteView(APIView):
+    @swagger_auto_schema(
+        operation_id="이력서 삭제"
+    )
+    def delete(self, request, resume_id):
+        resume = Resume.objects.get(id=resume_id)
+        file_path = resume.file_url.replace(settings.MEDIA_URL, "")
+        default_storage.delete(file_path)
+        resume.delete()
+        return Response({"message": "이력서 삭제 성공"}, status=status.HTTP_200_OK)


### PR DESCRIPTION
# 설명
- 이력서 삭제 기능 

# 작업내용
- 이력서를 삭제하는 DELETE api 엔드포인트
- resume_id 매칭으로 이력서를 **S3에서 삭제** 후 **db에서 삭제**


(이슈에 대한 작업완료시) close #이슈번호

* 모든 내용은 한글로 작성
