### PR TITLE
[fix/#61] :이력서 업로드 api 오류 수정

### DIFF
--- a/resume/urls.py
+++ b/resume/urls.py
@@ -4,7 +4,7 @@ from resume import views
 appname = "resume"
 
 urlpatterns = [
-    path("upload/<user_id>", views.ResumeUploadView.as_view(), name="upload"),
-    path("list/<user_id>", views.ResumeListView.as_view(), name="resumes-list"),
-    path("delete/<resume_id>", views.ResumeDeleteView.as_view(), name="delete"),
+    path("upload/", views.ResumeUploadView.as_view(), name="upload"),
+    path("list/", views.ResumeListView.as_view(), name="resumes-list"),
+    path("delete/<int:resume_id>", views.ResumeDeleteView.as_view(), name="delete"),
 ]

--- a/resume/views.py
+++ b/resume/views.py
@@ -45,7 +45,8 @@ class ResumeListView(APIView):
     @swagger_auto_schema(
         operation_id="이력서 조회",
     )
-    def get(self, request, user_id):
+    def get(self, request):
+        user_id = request.user.id
         resumes = Resume.objects.filter(user_id=user_id)
         resume_list = [
             {


### PR DESCRIPTION
# 설명
- 이력서 업로드 api 오류 수정

# 작업내용
- 이력서 업로드 api에서 member_id를 요청값으로 잘못 넘겨주면서 오류 발생 
- memebr_id를 요청값에서 제외하고 토큰으로 사용자 인증하도록 수정 


(이슈에 대한 작업완료시) close #이슈번호

* 모든 내용은 한글로 작성
