### PR TITLE
[fix/#72] 면접결과 삭제 api 수정

### DIFF
--- a/result/urls.py
+++ b/result/urls.py
@@ -7,5 +7,5 @@ urlpatterns = [
     path("upload/<int:interview_id>", views.ResultVideoUploadView.as_view(), name="video-upload"),
     path("list", views.ResultListView.as_view(), name="results-list"),
     path("<int:result_id>", views.ResultOpenView.as_view(), name="result-open"),
-    path("delete/<int:interview_id>", views.ResultDeleteView.as_view(), name="result-delete"),
+    path("delete/<int:result_id>", views.ResultDeleteView.as_view(), name="result-delete"),
 ]

--- a/result/views.py
+++ b/result/views.py
@@ -95,7 +95,9 @@ class ResultDeleteView(APIView):
         operation_id="면접결과 삭제",
         operation_description="면접결과를 삭제하는 API"
     )
-    def delete(self, request, interview_id):
-        interview = Interview.objects.get(id=interview_id)
+    def delete(self, request, result_id):
+        result = Result.objects.select_related("interview").get(id=result_id)
+        interview = result.interview
+        result.delete()
         interview.delete()
         return Response({"message": "면접결과 삭제 성공"}, status=status.HTTP_200_OK)


### PR DESCRIPTION
# 설명
- 면접결과 삭제 api 수정

# 작업내용
- url 파라미터 변경 (interview_id -> result_id)


(이슈에 대한 작업완료시) close #이슈번호

* 모든 내용은 한글로 작성
